### PR TITLE
feat(auth): 리다이렉션 대응을 위한 인증 여부 응답 추가

### DIFF
--- a/src/main/java/com/example/nihongo/common/dto/response/auth/EmailAuthResponseDto.java
+++ b/src/main/java/com/example/nihongo/common/dto/response/auth/EmailAuthResponseDto.java
@@ -1,0 +1,26 @@
+package com.example.nihongo.common.dto.response.auth;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.example.nihongo.common.dto.response.ResponseDto;
+import com.example.nihongo.common.dto.response.ResponseType;
+
+import lombok.Getter;
+
+@Getter
+public class EmailAuthResponseDto extends ResponseDto {
+
+  private boolean isVerified;
+
+  private EmailAuthResponseDto(boolean isVerified) {
+    super(ResponseType.SUCCESS);
+    this.isVerified = isVerified;
+  }
+
+  public static ResponseEntity<EmailAuthResponseDto> success(boolean isVerified) {
+    EmailAuthResponseDto body = new EmailAuthResponseDto(isVerified);
+    return ResponseEntity.status(HttpStatus.OK).body(body);
+  }
+  
+}

--- a/src/main/java/com/example/nihongo/common/dto/response/auth/SignInResponseDto.java
+++ b/src/main/java/com/example/nihongo/common/dto/response/auth/SignInResponseDto.java
@@ -28,15 +28,18 @@ public class SignInResponseDto extends ResponseDto {
    */
   private Integer expiration;
 
+  private boolean isVerified;
+
   /**
    * description: 응답 객체를 생성합니다.
    *
    * @param accessToken 클라이언트에게 발급할 액세스 토큰
    */
-  public SignInResponseDto(String accessToken) {
+  public SignInResponseDto(String accessToken, boolean isVerified) {
     super(ResponseType.SUCCESS);
     this.accessToken = accessToken;
     this.expiration = 60 * 60 * 9; // 9시간 (초 단위)
+    this.isVerified = isVerified;
   }
 
   /**
@@ -45,8 +48,8 @@ public class SignInResponseDto extends ResponseDto {
    * @param accessToken 발급할 액세스 토큰
    * @return 200 OK 상태의 로그인 응답
    */
-  public static ResponseEntity<SignInResponseDto> success(String accessToken) {
-    SignInResponseDto body = new SignInResponseDto(accessToken);
+  public static ResponseEntity<SignInResponseDto> success(String accessToken, boolean isVerified) {
+    SignInResponseDto body = new SignInResponseDto(accessToken, isVerified);
     return ResponseEntity.status(HttpStatus.OK).body(body);
   }
 }

--- a/src/main/java/com/example/nihongo/controller/AuthController.java
+++ b/src/main/java/com/example/nihongo/controller/AuthController.java
@@ -12,6 +12,7 @@ import com.example.nihongo.common.dto.request.auth.EmailCheckRequestDto;
 import com.example.nihongo.common.dto.request.auth.SignInRequestDto;
 import com.example.nihongo.common.dto.request.auth.SignUpRequestDto;
 import com.example.nihongo.common.dto.response.ResponseDto;
+import com.example.nihongo.common.dto.response.auth.EmailAuthResponseDto;
 import com.example.nihongo.common.dto.response.auth.SignInResponseDto;
 import com.example.nihongo.service.AuthService;
 import com.example.nihongo.service.EmailAuthService;
@@ -60,10 +61,10 @@ public class AuthController {
   }
 
   @PostMapping("/verify-email")
-  public ResponseEntity<ResponseDto> verifyEmail(
+  public ResponseEntity<? super EmailAuthResponseDto> verifyEmail(
     @RequestBody @Valid EmailAuthVerifyRequestDto requestBody
   ){
-    ResponseEntity<ResponseDto> response = emailAuthService.verifyEmail(requestBody, requestBody.getEmail());
+    ResponseEntity<? super EmailAuthResponseDto> response = emailAuthService.verifyEmail(requestBody, requestBody.getEmail());
     return response;
   }
   

--- a/src/main/java/com/example/nihongo/repository/UserRepository.java
+++ b/src/main/java/com/example/nihongo/repository/UserRepository.java
@@ -23,4 +23,6 @@ public interface UserRepository extends JpaRepository<UserEntity, String>{
    * @return 해당 이메일을 가진 사용자 엔티티
    */
   UserEntity findByEmail(String email);
+
+  UserEntity findByEmailAndIsVerified(String email, boolean isVerified);
 }

--- a/src/main/java/com/example/nihongo/service/EmailAuthService.java
+++ b/src/main/java/com/example/nihongo/service/EmailAuthService.java
@@ -5,8 +5,9 @@ import org.springframework.http.ResponseEntity;
 import com.example.nihongo.common.dto.request.auth.EmailAuthSendRequestDto;
 import com.example.nihongo.common.dto.request.auth.EmailAuthVerifyRequestDto;
 import com.example.nihongo.common.dto.response.ResponseDto;
+import com.example.nihongo.common.dto.response.auth.EmailAuthResponseDto;
 
 public interface  EmailAuthService {
   ResponseEntity<ResponseDto> sendEmail(EmailAuthSendRequestDto dto, String email);
-  ResponseEntity<ResponseDto> verifyEmail(EmailAuthVerifyRequestDto dto, String email);
+  ResponseEntity<? super EmailAuthResponseDto> verifyEmail(EmailAuthVerifyRequestDto dto, String email);
 }

--- a/src/main/java/com/example/nihongo/service/implement/AuthServiceImplement.java
+++ b/src/main/java/com/example/nihongo/service/implement/AuthServiceImplement.java
@@ -30,11 +30,12 @@ public class AuthServiceImplement implements AuthService{
   public ResponseEntity<? super SignInResponseDto> signIn(SignInRequestDto dto) {
 
     String accessToken = null;
+    UserEntity userEntity = null;
 
     try {
         
       String email = dto.getEmail();
-      UserEntity userEntity = userRepository.findByEmail(email);
+      userEntity = userRepository.findByEmail(email);
       if (userEntity == null) return ResponseDto.signInFail();
 
       String password = dto.getPassword();
@@ -49,7 +50,7 @@ public class AuthServiceImplement implements AuthService{
       return ResponseDto.databaseError();
     }
 
-    return SignInResponseDto.success(accessToken);
+    return SignInResponseDto.success(accessToken, userEntity.isVerified());
 
   }
 

--- a/src/main/java/com/example/nihongo/service/implement/EmailAuthServiceImplement.java
+++ b/src/main/java/com/example/nihongo/service/implement/EmailAuthServiceImplement.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import com.example.nihongo.common.dto.request.auth.EmailAuthSendRequestDto;
 import com.example.nihongo.common.dto.request.auth.EmailAuthVerifyRequestDto;
 import com.example.nihongo.common.dto.response.ResponseDto;
+import com.example.nihongo.common.dto.response.auth.EmailAuthResponseDto;
 import com.example.nihongo.common.entity.EmailAuthEntity;
 import com.example.nihongo.common.entity.UserEntity;
 import com.example.nihongo.repository.EmailAuthRepository;
@@ -70,9 +71,10 @@ public class EmailAuthServiceImplement implements EmailAuthService {
   }
 
   @Override
-  public ResponseEntity<ResponseDto> verifyEmail(EmailAuthVerifyRequestDto dto, String email) {
+  public ResponseEntity<? super EmailAuthResponseDto> verifyEmail(EmailAuthVerifyRequestDto dto, String email) {
 
     Integer code = Integer.valueOf(dto.getCode());
+    UserEntity userEntity = null;
 
 
     try {
@@ -80,7 +82,7 @@ public class EmailAuthServiceImplement implements EmailAuthService {
       EmailAuthEntity emailAuthEntity = emailAuthRepository.findByEmail(email);
       if (emailAuthEntity == null || !emailAuthEntity.getCode().equals(code)) return ResponseDto.validationFail();
    
-      UserEntity userEntity = userRepository.findByEmail(email);
+      userEntity = userRepository.findByEmail(email);
       if (userEntity == null) return ResponseDto.validationFail();
 
       userEntity.setVerified(true);
@@ -92,7 +94,7 @@ public class EmailAuthServiceImplement implements EmailAuthService {
       return ResponseDto.databaseError();
     }
 
-    return ResponseDto.success(HttpStatus.OK);
+    return EmailAuthResponseDto.success(userEntity.isVerified());
 
   }
   


### PR DESCRIPTION
## 주요 변경 사항

- 로그인 응답에 isVerified 필드 추가
- 이메일 인증 응답 생성
- 이메일 인증 응답 타입 변경 (ResponseDto → EmailAuthResponseDto)
- 이메일 인증 여부 조회 메서드 추가

## 참고

- 클라이언트에서 로그인 후 리다이렉션 처리 시 이메일 인증 여부 확인을 위해 해당 필드가 필요함
- 이메일 인증 상태에 따라 다른 페이지로 분기 처리 가능